### PR TITLE
Support py_library resources

### DIFF
--- a/build_env.py
+++ b/build_env.py
@@ -66,8 +66,8 @@ def get_site_packages_path(
 
     if not is_external:
         # If the input wasn't an external path and it didn't match any import prefixes,
-        # just return it as given.
-        return path
+        # return it after stripping the parent directory.
+        return path.relative_to(path.parts[0])
 
     # External file that didn't match imports. Include but warn.
     # We include it as relative to its workspace directory, so strip the first component
@@ -103,10 +103,6 @@ def get_files(build_env_input: Dict) -> List[EnvFile]:
         # Only generated workspace files are kept.
         type_ = depfile["t"]
         input_path = pathlib.Path(depfile["p"])
-
-        # Only add external and generated files
-        if not (is_external(input_path) or type_ == "G"):
-            continue
 
         # If this is a directory, expand to each recursive child.
         if input_path.is_dir():

--- a/venv.bzl
+++ b/venv.bzl
@@ -26,7 +26,8 @@ def _py_venv_deps_impl(ctx):
             continue
         imports.extend([i for i in dep[PyInfo].imports.to_list() if i not in imports])
 
-    deps = depset(transitive = [dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps])
+    deps = depset(transitive = [dep[DefaultInfo].default_runfiles.files for dep in ctx.attr.deps] +
+                               [dep[DefaultInfo].files for dep in ctx.attr.deps])
     out = ctx.outputs.output
 
     files = []
@@ -76,7 +77,7 @@ def py_venv(name, deps = None, extra_pip_commands = None):
     py_binary(
         name = name,
         srcs = ["@rules_pyvenv//:build_env.py"],
-	deps = ["@rules_pyvenv//vendor/importlib_metadata"],
+        deps = ["@rules_pyvenv//vendor/importlib_metadata"],
         data = [out_label] + deps,
         main = "@rules_pyvenv//:build_env.py",
         env = {


### PR DESCRIPTION
This PR adds the ability to expose `py_library` modules inside the generated virtual environment.

For example, a workspace structure like this:

```
.
├── BUILD.bazel
├── test_python
│   ├── BUILD.bazel
│   ├── singlefile.py
│   └── test_module
│       ├── __init__.py
│       ├── library.py
│       └── version.py
└── WORKSPACE.bazel
```

That has the following in `test_python/BUILD.bazel`:

```Starlark
py_library(
    name = "test_module",
    srcs = [
        "test_module/__init__.py",
        "test_module/library.py",
        "test_module/version.py",
    ],
)

py_library(
    name = "singlefile",
    srcs = [
        "singlefile.py",
    ],
)
```

and a basic root `BUILD.bazel`

```Starlark
py_venv(
    name = "venv",
    deps = [
        "//test_python:test_module",
        "//test_python:singlefile",
    ],
)
```

will generate a virtual environment that contains both `test_module` as well as `singlefile.py`:

```
.venv/lib/python3.8/site-packages
├── singlefile.py -> /path/to/workspace/test_python/singlefile.py
└── test_module
    ├── __init__.py -> /path/to/workspace/test_python/test_module/__init__.py
    ├── library.py -> /path/to/workspace/test_python/test_module/library.py
    └── version.py -> /path/to/workspace/test_python/test_module/version.py
```

There's a chance that this PR breaks support for local generated files since it modifies the behavior of `get_site_packages_path`. I'm not sure of the best way to check that.

Closes #1 