### PR TITLE
Create venv relative to workspace directory

### DIFF
--- a/build_env.py
+++ b/build_env.py
@@ -217,7 +217,7 @@ def run_additional_commands(env_path: pathlib.Path, commands: List[str]) -> None
 def main():
     if "BUILD_ENV_INPUT" not in os.environ:
         raise Exception("Missing BUILD_ENV_INPUT environment variable")
-    if len(sys.argv) != 2:
+    if "VENV_LOCATION" not in os.environ and len(sys.argv) != 2:
         raise Exception(f"Usage: {sys.argv} <venv path>")
 
     with open(os.environ["BUILD_ENV_INPUT"]) as f:
@@ -229,8 +229,11 @@ def main():
     # files in their actual location
     sys._base_executable = str(pathlib.Path(sys._base_executable).resolve())
 
-    cwd = os.environ.get("BUILD_WORKING_DIRECTORY", os.getcwd())
-    env_path = pathlib.Path(cwd) / pathlib.Path(sys.argv[1])
+    if "VENV_LOCATION" in os.environ:
+        env_path = pathlib.Path(os.environ["BUILD_WORKSPACE_DIRECTORY"]) / os.environ["VENV_LOCATION"]
+    else:
+        cwd = os.environ.get("BUILD_WORKING_DIRECTORY", os.getcwd())
+        env_path = pathlib.Path(cwd) / pathlib.Path(sys.argv[1])
 
     builder = venv.EnvBuilder(clear=True, symlinks=True, with_pip=True)
     builder.create(str(env_path))

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -47,6 +47,15 @@ py_venv(
     always_link = True,
 )
 
+py_venv(
+    name = "venv_relative_workspace_root",
+    venv_location = ".venv",
+    deps = [
+        "//libraries/liba",
+        "//libraries/libb",
+    ],
+)
+
 compile_pip_requirements(
     name = "requirements",
     extra_args = ["--allow-unsafe"],

--- a/venv.bzl
+++ b/venv.bzl
@@ -61,7 +61,7 @@ _py_venv_deps = rule(
     toolchains = [PYTHON_TOOLCHAIN_TYPE],
 )
 
-def py_venv(name, deps = None, extra_pip_commands = None, always_link = False, **kwargs):
+def py_venv(name, deps = None, extra_pip_commands = None, always_link = False, venv_location = None, **kwargs):
     deps = deps or []
     extra_pip_commands = extra_pip_commands or []
 
@@ -77,14 +77,19 @@ def py_venv(name, deps = None, extra_pip_commands = None, always_link = False, *
         **kwargs,
     )
 
+    env = {
+        "BUILD_ENV_INPUT": "$(location " + out_label + ")",
+    }
+
+    if venv_location:
+        env.update({"VENV_LOCATION": venv_location})
+
     py_binary(
         name = name,
         srcs = ["@rules_pyvenv//:build_env.py"],
         deps = ["@rules_pyvenv//vendor/importlib_metadata"],
         data = [out_label] + deps,
         main = "@rules_pyvenv//:build_env.py",
-        env = {
-            "BUILD_ENV_INPUT": "$(location " + out_label + ")",
-        },
+        env = env,
         **kwargs,
     )


### PR DESCRIPTION
This PR modifies the behavior of `build_env.py` so that it always creates a virtual environment relative to the workspace root. The previous behavior was to create the venv relative to the directory you run `bazel run ...` in. This change makes it so that it doesn't matter what subdirectory you're in when running bazel. [Here's a link](https://bazel.build/docs/user-manual#running-executables) to the bazel docs where I found the new environment variable to use.