### PR TITLE
forward extra kwargs from py_venv to its internal targets

### DIFF
--- a/venv.bzl
+++ b/venv.bzl
@@ -59,7 +59,7 @@ _py_venv_deps = rule(
     toolchains = [PYTHON_TOOLCHAIN_TYPE],
 )
 
-def py_venv(name, deps = None, extra_pip_commands = None):
+def py_venv(name, deps = None, extra_pip_commands = None, **kwargs):
     deps = deps or []
     extra_pip_commands = extra_pip_commands or []
 
@@ -71,15 +71,17 @@ def py_venv(name, deps = None, extra_pip_commands = None):
         deps = deps,
         commands = extra_pip_commands,
         output = out_name,
+        **kwargs,
     )
 
     py_binary(
         name = name,
         srcs = ["@rules_pyvenv//:build_env.py"],
-	deps = ["@rules_pyvenv//vendor/importlib_metadata"],
+        deps = ["@rules_pyvenv//vendor/importlib_metadata"],
         data = [out_label] + deps,
         main = "@rules_pyvenv//:build_env.py",
         env = {
             "BUILD_ENV_INPUT": "$(location " + out_label + ")",
         },
+        **kwargs,
     )


### PR DESCRIPTION
The `py_venv`-macro does not accept any of Bazel's [common build rule attributes](https://bazel.build/reference/be/common-definitions#typical-attributes) because it limits itself to the 3 arguments it knows about. This PR makes it so that the macro accepts any extra arguments that are valid for both the internal `_py_venv_deps` and `py_binary` target and forwards them to those targets.

After this change, things like `tags`, `visibility` or `testonly` are supported on `py_venv` and have the expected behaviour.