### PR TITLE
Better support for local libraries

### DIFF
--- a/build_env.py
+++ b/build_env.py
@@ -98,6 +98,7 @@ def find_site_packages(env_path: pathlib.Path) -> pathlib.Path:
 def get_files(build_env_input: Dict) -> List[EnvFile]:
     files = []
 
+    always_link = build_env_input.get("always_link", False)
     imports = [pathlib.Path(imp) for imp in build_env_input["imports"]]
     workspace = build_env_input["workspace"]
     for depfile in build_env_input["files"]:
@@ -105,10 +106,6 @@ def get_files(build_env_input: Dict) -> List[EnvFile]:
         # Only generated workspace files are kept.
         type_ = depfile["t"]
         input_path = pathlib.Path(depfile["p"])
-
-        # Only add external and generated files
-        if not (is_external(input_path) or type_ == "G"):
-            continue
 
         # If this is a directory, expand to each recursive child.
         if input_path.is_dir():
@@ -119,7 +116,8 @@ def get_files(build_env_input: Dict) -> List[EnvFile]:
 
         for path in paths:
             site_packages_path = get_site_packages_path(workspace, path, imports)
-            files.append(EnvFile(path, site_packages_path))
+            if site_packages_path != path or always_link:
+                files.append(EnvFile(path, site_packages_path))
 
     return files
 

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -21,12 +21,30 @@ load("@rules_python//python/pip_install:requirements.bzl", "compile_pip_requirem
 py_venv(
     name = "venv",
     deps = [
+	"//libraries/liba",
         requirement("black"),
         requirement("numpy"),
     ],
     extra_pip_commands = [
 #        "install ipython jupyter-console",
     ]
+)
+
+py_venv(
+    name = "venv_only_local",
+    deps = [
+        "//libraries/liba",
+        "//libraries/libb",
+    ],
+)
+
+py_venv(
+    name = "venv_only_local_always_link",
+    deps = [
+        "//libraries/liba",
+        "//libraries/libb",
+    ],
+    always_link = True,
 )
 
 compile_pip_requirements(

--- a/example/libraries/liba/BUILD.bazel
+++ b/example/libraries/liba/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "liba",
+    srcs = ["liba.py"],
+    imports = ["."],
+)
+

--- a/example/libraries/liba/liba.py
+++ b/example/libraries/liba/liba.py
@@ -1,0 +1,3 @@
+def foo():
+    pass
+

--- a/example/libraries/libb/BUILD.bazel
+++ b/example/libraries/libb/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "libb",
+    srcs = ["libb.py"],
+)
+

--- a/example/libraries/libb/libb.py
+++ b/example/libraries/libb/libb.py
@@ -1,0 +1,3 @@
+def foo():
+    pass
+

--- a/venv.bzl
+++ b/venv.bzl
@@ -44,6 +44,7 @@ def _py_venv_deps_impl(ctx):
         "imports": imports,
         "files": files,
         "commands": ctx.attr.commands,
+        "always_link": ctx.attr.always_link,
     }
     ctx.actions.write(out, json.encode(doc))
 
@@ -54,12 +55,13 @@ _py_venv_deps = rule(
     attrs = {
         "deps": attr.label_list(),
         "commands": attr.string_list(),
+        "always_link": attr.bool(),
         "output": attr.output(),
     },
     toolchains = [PYTHON_TOOLCHAIN_TYPE],
 )
 
-def py_venv(name, deps = None, extra_pip_commands = None, **kwargs):
+def py_venv(name, deps = None, extra_pip_commands = None, always_link = False, **kwargs):
     deps = deps or []
     extra_pip_commands = extra_pip_commands or []
 
@@ -70,6 +72,7 @@ def py_venv(name, deps = None, extra_pip_commands = None, **kwargs):
         name = deps_name,
         deps = deps,
         commands = extra_pip_commands,
+        always_link = always_link,
         output = out_name,
         **kwargs,
     )


### PR DESCRIPTION
If a py_library is included in a venv and uses the imports attr, it will
be linked into the site-packages directory with the proper path.

Additionally, an always_link attr is added that, when True, will allways
link py_library targets into site-packages even if they don't specify
imports.
