### PR TITLE
Use PyInfo from rules_python for rules_pycross compatibility

### DIFF
--- a/venv.bzl
+++ b/venv.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:py_info.bzl", "PyInfo")
 
 PYTHON_TOOLCHAIN_TYPE = "@bazel_tools//tools/python:toolchain_type"
 


### PR DESCRIPTION
we're using `rules_pyvenv` together with `rules_pycross` like this:

`MODULE.bazel`:
```starlark
lock_import = use_extension("@rules_pycross//pycross/extensions:lock_import.bzl", "lock_import")
lock_import.import_pdm(
    lock_file = "//:pdm.lock",
    project_file = "//:pyproject.toml",
    repo = "pip",
)
```

`BUILD.bazel`:
```starlark
load("@pip//:requirements.bzl", "all_requirements")
load("@rules_pyvenv//:venv.bzl", "py_venv")

py_venv(
    name = "venv",
    deps = all_requirements,
    tags = ["manual"],
)
```

without this PR the created venv is unusable, as the imports are not being detected.